### PR TITLE
Remove newlines from `setup(description=...)`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     license='BSD',
     author='Georg Brandl',
     author_email='georg@python.org',
-    description=long_desc,
+    description=long_desc.strip().replace('\n', ' '),
     long_description=long_desc,
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
This package's `setup.py` uses a string containing newlines as `setup()`'s `description` parameter, thereby triggering the bug pypa/setuptools#1390 and causing the package's metadata to be malformed.  You can see the results of this malformation at https://pypi.org/project/sphinxcontrib-devhelp/1.0.1/, with fields like the classifiers erroneously appearing in the package description rather than in the sidebar.  This PR removes the newlines from the string, thereby fixing the metadata.