### PR TITLE
Use ``Node.findall`` instead of ``Node.traverse``.

### DIFF
--- a/sphinxcontrib/devhelp/__init__.py
+++ b/sphinxcontrib/devhelp/__init__.py
@@ -93,7 +93,7 @@ class DevhelpBuilder(StandaloneHTMLBuilder):
                 parent.attrib['name'] = node.astext()
 
         matcher = NodeMatcher(addnodes.compact_paragraph, toctree=Any)
-        for node in tocdoc.traverse(matcher):  # type: addnodes.compact_paragraph
+        for node in tocdoc.findall(matcher):  # type: addnodes.compact_paragraph
             write_toc(node, chapters)
 
         # Index


### PR DESCRIPTION
Fix https://github.com/sphinx-doc/sphinx/issues/11600