### PR TITLE
[patch] use config.root_doc instead of config.master_doc

### DIFF
--- a/sphinxcontrib/devhelp/__init__.py
+++ b/sphinxcontrib/devhelp/__init__.py
@@ -77,7 +77,7 @@ class DevhelpBuilder(StandaloneHTMLBuilder):
         chapters = etree.SubElement(root, 'chapters')
 
         tocdoc = self.env.get_and_resolve_doctree(
-            self.config.master_doc, self, prune_toctrees=False)
+            self.config.root_doc, self, prune_toctrees=False)
 
         def write_toc(node: nodes.Node, parent: etree.Element) -> None:
             if isinstance(node, addnodes.compact_paragraph) or \


### PR DESCRIPTION
Projects configured with `root_doc` fail to build (see https://github.com/sphinx-doc/sphinx/issues/12416).

I'll also work on fixing the `master_doc <-> root_doc` desynchronization.