### PR TITLE
Avoid storing build time in gzip headers

### DIFF
--- a/sphinxcontrib/devhelp/__init__.py
+++ b/sphinxcontrib/devhelp/__init__.py
@@ -124,7 +124,7 @@ class DevhelpBuilder(StandaloneHTMLBuilder):
 
         # Dump the XML file
         xmlfile = path.join(outdir, outname + '.devhelp.gz')
-        with gzip.open(xmlfile, 'w') as f:
+        with gzip.GzipFile(filename=xmlfile, mode='w', mtime=0) as f:
             tree.write(f, 'utf-8')  # type: ignore
 
 

--- a/tests/test_devhelp.py
+++ b/tests/test_devhelp.py
@@ -1,4 +1,5 @@
 """Test for devhelp extension."""
+from time import sleep
 
 import pytest
 
@@ -6,3 +7,19 @@ import pytest
 @pytest.mark.sphinx('devhelp', testroot='basic')
 def test_basic(app, status, warning):
     app.builder.build_all()
+
+
+@pytest.mark.sphinx('devhelp', testroot='basic', freshenv=True)
+def test_basic_deterministic_build(app):
+    app.config.devhelp_basename, output_filename = 'testing', 'testing.devhelp.gz'
+
+    app.builder.build_all()
+    output_initial = (app.outdir / output_filename).read_bytes()
+
+    sleep(2)
+
+    app.builder.build_all()
+    output_repeat = (app.outdir / output_filename).read_bytes()
+
+    msg = f"Content of '{output_filename}' differed between builds."
+    assert output_repeat == output_initial, msg


### PR DESCRIPTION
This allows to create bit-reproducible Python3.12/Python.devhelp.gz output.

See https://reproducible-builds.org/ for why this is good.

This patch was done while working on reproducible builds for openSUSE, sponsored by the NLnet NGI0 fund.