### PR TITLE
Sphinx v8 compatibility: separate the names of two mutually-shadowing variables whose types have diverged

### DIFF
--- a/sphinxcontrib/devhelp/__init__.py
+++ b/sphinxcontrib/devhelp/__init__.py
@@ -118,8 +118,8 @@ class DevhelpBuilder(StandaloneHTMLBuilder):
                     write_index("%s %s" % (parent_title, subitem[0]),
                                 subitem[1], [])
 
-        for (key, group) in index:
-            for title, (refs, subitems, key) in group:
+        for (_group_key, group) in index:
+            for title, (refs, subitems, _category_key) in group:
                 write_index(title, refs, subitems)
 
         # Dump the XML file


### PR DESCRIPTION
The values of these `key` variables would have clobbered each other in the past; their value is not used in subsequent code, however, so this value-overwriting behaviour does not have any impact on runtime behaviour.

Prior to Sphinx v8, both of them had type `str`, and so `mypy` did not detect a problem.  With Sphinx v8 their types diverge as a result of sphinx-doc/sphinx#12575 - one of them remains `str` and the other becomes `str | None`.

By assigning each of them a distinct variable name, this changeset resolves `mypy` validation errors when the Sphinx v8.0.0 codebase is installed as a type-checking dependency (discovered during #13).

cc @AA-Turner 