### PR TITLE
Require Python 3.12 for mypy in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ include = [
 ]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.12"
 packages = [
     "sphinxcontrib",
     "tests",


### PR DESCRIPTION
Otherwise we are getting a mismatch of incompatible annotations inside the Python code.